### PR TITLE
style: add perplexity-like layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+apps/backend/dist/
+apps/frontend/.next/
+apps/frontend/next-env.d.ts
+*.log

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -5,8 +5,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <title>Wizkid</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body className="min-h-screen antialiased">
-        <div className="max-w-4xl mx-auto p-6">{children}</div>
+      <body className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-black text-gray-100 antialiased">
+        <div className="max-w-3xl mx-auto p-6">{children}</div>
       </body>
     </html>
   );

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -59,16 +59,19 @@ export default function Home() {
   }
 
   return (
-    <main>
-      <h1 className="text-3xl font-bold mb-4">Wizkid</h1>
-      <form onSubmit={ask} className="flex gap-2 mb-6">
+    <main className="flex flex-col items-center">
+      <h1 className="text-3xl font-bold mb-8 text-center">Wizkid</h1>
+      <form onSubmit={ask} className="w-full flex gap-2 mb-6">
         <input
           value={query}
           onChange={(e)=>setQuery(e.target.value)}
-          className="flex-1 rounded-xl px-4 py-3 bg-white/10 outline-none"
+          className="w-full rounded-xl px-4 py-3 bg-white/10 outline-none border border-white/20"
           placeholder="Ask anything..."
         />
-        <button className="px-5 py-3 rounded-xl bg-white/20 hover:bg-white/30" type="submit">
+        <button
+          className="px-5 py-3 rounded-xl bg-gradient-to-r from-blue-500 to-cyan-500 text-white hover:from-blue-600 hover:to-cyan-600"
+          type="submit"
+        >
           Ask
         </button>
       </form>


### PR DESCRIPTION
## Summary
- add gradient background and centered layout to mimic Perplexity
- introduce gradient search button and centered form
- ignore build artifacts and dependencies with .gitignore

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af01e830f0832f9b26c8f76db1c8d8