### PR TITLE
Add environment variable example and runtime checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SEARCH_API_KEY=your_search_api_key_here
+LLM_API_KEY=your_llm_api_key_here
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
+.next/
 apps/backend/dist/
 apps/frontend/.next/
 apps/frontend/next-env.d.ts
 *.log
+.env

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Single-repo **Next.js 14** app with:
 
 ## Run locally
 ```bash
+cp .env.example .env # set SEARCH_API_KEY and LLM_API_KEY
 npm install
 npm run dev
 # open http://localhost:3000

--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -6,6 +6,15 @@ function sleep(ms: number) { return new Promise(res => setTimeout(res, ms)); }
 export async function POST(req: Request) {
   const { query, style = 'simple' } = await req.json();
 
+  const searchKey = process.env.SEARCH_API_KEY;
+  const llmKey = process.env.LLM_API_KEY;
+  if (!searchKey) {
+    return new Response('Missing SEARCH_API_KEY in environment', { status: 500 });
+  }
+  if (!llmKey) {
+    return new Response('Missing LLM_API_KEY in environment', { status: 500 });
+  }
+
   const stream = new ReadableStream({
     async start(controller) {
       const enc = new TextEncoder();


### PR DESCRIPTION
## Summary
- provide `.env.example` with `SEARCH_API_KEY` and `LLM_API_KEY`
- document environment variable setup in README
- validate required keys in `/api/ask` route and ignore `.env`/`.next` in git

## Testing
- `npm test` *(fails: Missing script)*
- `SEARCH_API_KEY=dummy LLM_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af12ecfaa4832f9177557603af5fab