### PR TITLE
Add Google Generative AI dependency

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -34,7 +34,8 @@ export async function POST(req: Request) {
       // Enable Google Search tool (Gemini will search + return citations)
       const model = genAI.getGenerativeModel({
         model: 'gemini-1.5-flash',
-        tools: [{ googleSearch: {} }]
+        // Cast to any to allow googleSearch tool until types are available
+        tools: [{ googleSearch: {} }] as any
       });
 
       const sys = `You are Wizkid, a concise, citation-first assistant.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "next": "14.2.5",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "@google/generative-ai": "^0.24.1"
   },
   "devDependencies": {
     "typescript": "^5.5.4",


### PR DESCRIPTION
## Summary
- add @google/generative-ai package to dependencies
- loosen type on Google Search tool to compile with current SDK types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af32d9bfc4832f89dffcea67f15a97