### PR TITLE
Remove unsupported depth parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ Single-repo **Next.js 14** app with:
 - Streaming UI that displays the answer and source cards
 - Tailwind styling
 
+## API
+
+`POST /api/ask` expects a JSON body like:
+
+```json
+{ "query": "What is Wizkid?", "style": "simple" }
+```
+
+The `style` field is optional and may be `simple` or `expert` (defaults to `simple`).
+
 ## Run locally
 ```bash
 cp .env.example .env # set SEARCH_API_KEY and LLM_API_KEY

--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -4,6 +4,8 @@ export const dynamic = 'force-dynamic';
 
 import { GoogleGenerativeAI } from '@google/generative-ai';
 
+interface AskRequest { query: string; style?: 'simple' | 'expert'; }
+
 function enc(s: string) { return new TextEncoder().encode(s); }
 function sse(write: (s: string) => void) {
   return (o: any) => write(`data: ${JSON.stringify(o)}\n\n`);
@@ -14,7 +16,7 @@ function rid() {
 }
 
 export async function POST(req: Request) {
-  const { query, style = 'simple' } = await req.json();
+  const { query, style = 'simple' } = await req.json() as AskRequest;
 
   const searchKey = process.env.SEARCH_API_KEY;
   const llmKey = process.env.LLM_API_KEY;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useRef } from 'react';
 
 type Cite = { id: string; url: string; title: string; snippet?: string; quote?: string; published_at?: string };
+type AskRequest = { query: string; style: 'simple' | 'expert' };
 
 export default function Home() {
   const [query, setQuery] = useState('What is Wizkid?');
@@ -21,10 +22,11 @@ export default function Home() {
     const ac = new AbortController();
     abortRef.current = ac;
 
+    const payload: AskRequest = { query, style: 'simple' };
     const resp = await fetch('/api/ask', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query, depth: 'standard', style: 'simple' }),
+      body: JSON.stringify(payload),
       signal: ac.signal,
     });
 


### PR DESCRIPTION
## Summary
- remove unused `depth` option from ask payload
- define typed request payload on client and server
- document `/api/ask` request format

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afd2641750832f9a0b83ac6d320c5b