### PR TITLE
Wrap Gemini call in try/catch

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -51,17 +51,24 @@ export async function POST(req: Request) {
 Use inline [n] citations; prefer official/primary sources.
 Style: ${style === 'expert' ? 'Expert (lawyer-grade)' : 'Simple'}.`;
 
-      const result = await model.generateContentStream({
-        contents: [{ role: 'user', parts: [{ text: `${sys}\n\nQuestion: ${query}` }] }]
-      });
+      let result: any;
+      try {
+        result = await model.generateContentStream({
+          contents: [{ role: 'user', parts: [{ text: `${sys}\n\nQuestion: ${query}` }] }]
+        });
 
-      let finalResponse: any = null;
+        let finalResponse: any = null;
 
-      for await (const event of result.stream) {
-        // Each event can be turned into text
-        const text = (event as any).text?.();
-        if (text) send({ event: 'token', text });
-        finalResponse = event; // keep last for metadata
+        for await (const event of result.stream) {
+          // Each event can be turned into text
+          const text = (event as any).text?.();
+          if (text) send({ event: 'token', text });
+          finalResponse = event; // keep last for metadata
+        }
+      } catch (err: any) {
+        send({ event: 'status', msg: `llm_error: ${err.message}` });
+        controller.close();
+        return;
       }
 
       // Try to gather citations from grounding metadata


### PR DESCRIPTION
## Summary
- wrap `model.generateContentStream` call in a try/catch to send SSE error events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afd354aed4832f9384ca281b7b2ec2