### PR TITLE
Revamp search UI with dynamic background and Wikipedia backend

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -2,8 +2,6 @@
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-import { GoogleGenerativeAI } from '@google/generative-ai';
-
 interface AskRequest { query: string; style?: 'simple' | 'expert'; }
 
 function enc(s: string) { return new TextEncoder().encode(s); }
@@ -16,91 +14,30 @@ function rid() {
 }
 
 export async function POST(req: Request) {
-  const { query, style = 'simple' } = await req.json() as AskRequest;
-
-  const searchKey = process.env.SEARCH_API_KEY;
-  const llmKey = process.env.LLM_API_KEY;
-  if (!searchKey) {
-    return new Response('Missing SEARCH_API_KEY in environment', { status: 500 });
-  }
-  if (!llmKey) {
-    return new Response('Missing LLM_API_KEY in environment', { status: 500 });
-  }
+  const { query } = await req.json() as AskRequest;
 
   const stream = new ReadableStream({
     async start(controller) {
       const send = sse((s) => controller.enqueue(enc(s)));
-
-      const apiKey = process.env.GEMINI_API_KEY;
-      if (!apiKey) {
-        send({ event: 'token', text: '**GEMINI_API_KEY missing**' });
-        send({ event: 'final', snapshot: { id: rid(), markdown: 'Missing key', cites: [], timeline: [], confidence: 'low' } });
-        controller.close();
-        return;
-      }
-
-      send({ event: 'status', msg: 'searching (Gemini + Google Search)' });
-
-      const genAI = new GoogleGenerativeAI(apiKey);
-      // Enable Google Search tool (Gemini will search + return citations)
-      const model = genAI.getGenerativeModel({
-        model: 'gemini-1.5-flash',
-        // Cast to any to allow googleSearch tool until types are available
-        tools: [{ googleSearch: {} }] as any
-      });
-
-      const sys = `You are Wizkid, a concise, citation-first assistant.
-Use inline [n] citations; prefer official/primary sources.
-Style: ${style === 'expert' ? 'Expert (lawyer-grade)' : 'Simple'}.`;
-
-      let result: any;
+      send({ event: 'status', msg: 'searching Wikipedia' });
       try {
-        result = await model.generateContentStream({
-          contents: [{ role: 'user', parts: [{ text: `${sys}\n\nQuestion: ${query}` }] }]
-        });
-
-        let finalResponse: any = null;
-
-        for await (const event of result.stream) {
-          // Each event can be turned into text
-          const text = (event as any).text?.();
-          if (text) send({ event: 'token', text });
-          finalResponse = event; // keep last for metadata
+        const res = await fetch(`https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(query)}`);
+        if (res.ok) {
+          const data = await res.json();
+          const text = data.extract || 'No summary available.';
+          const cite = { id: '1', url: data.content_urls?.desktop?.page || '', title: data.title };
+          send({ event: 'token', text });
+          send({ event: 'cite', cite });
+          send({
+            event: 'final',
+            snapshot: { id: rid(), markdown: text, cites: [cite], timeline: [], confidence: 'medium' }
+          });
+        } else {
+          send({ event: 'status', msg: 'no results found' });
         }
       } catch (err: any) {
-        send({ event: 'status', msg: `llm_error: ${err.message}` });
-        controller.close();
-        return;
+        send({ event: 'status', msg: `error: ${err.message}` });
       }
-
-      // Try to gather citations from grounding metadata
-      let cites: any[] = [];
-      try {
-        const full = await result.response;
-        const cand = (full as any)?.candidates?.[0];
-        const gm = cand?.groundingMetadata;
-        const chunks = gm?.groundingChunks || [];
-        cites = chunks.map((g: any, i: number) => {
-          const uri = g?.web?.uri || g?.retrievedContext?.uri;
-          const title = g?.web?.title || uri || `Source ${i + 1}`;
-          return uri ? { id: String(i + 1), url: uri, title } : null;
-        }).filter(Boolean);
-      } catch { /* ignore if missing */ }
-
-      // Emit source cards
-      for (const c of cites) send({ event: 'cite', cite: c });
-
-      send({
-        event: 'final',
-        snapshot: {
-          id: rid(),
-          markdown: '(streamed)',
-          cites,
-          timeline: [],
-          confidence: cites.length >= 3 ? 'high' : (cites.length ? 'medium' : 'low')
-        }
-      });
-
       controller.close();
     }
   });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,7 @@ export const metadata = { title: 'Wizkid' };
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen antialiased">
-        <div className="max-w-4xl mx-auto p-6">{children}</div>
-      </body>
+      <body className="min-h-screen antialiased">{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,24 @@
 'use client';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 type Cite = { id: string; url: string; title: string; snippet?: string; quote?: string; published_at?: string };
 type AskRequest = { query: string; style: 'simple' | 'expert' };
 
 export default function Home() {
-  const [query, setQuery] = useState('What is Wizkid?');
+  const [query, setQuery] = useState('');
   const [answer, setAnswer] = useState('');
-  const [status, setStatus] = useState<string|undefined>();
+  const [status, setStatus] = useState<string | undefined>();
   const [cites, setCites] = useState<Cite[]>([]);
-  const [confidence, setConfidence] = useState<string|undefined>();
-  const abortRef = useRef<AbortController|null>(null);
+  const [confidence, setConfidence] = useState<string | undefined>();
+  const abortRef = useRef<AbortController | null>(null);
+  const [bg, setBg] = useState('https://source.unsplash.com/1600x900/?ai');
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setBg(`https://source.unsplash.com/1600x900/?ai&sig=${Date.now()}`);
+    }, 10000);
+    return () => clearInterval(id);
+  }, []);
 
   async function ask(e: React.FormEvent) {
     e.preventDefault();
@@ -60,12 +68,39 @@ export default function Home() {
   }
 
   return (
-    <main>
-      <h1 className="text-3xl font-bold mb-4">Wizkid</h1>
-      <form onSubmit={ask} className="flex gap-2 mb-6">
+    <main className="relative min-h-screen pb-40">
+      <div className="absolute inset-x-0 top-0 h-1/2 -z-10 overflow-hidden">
+        <img src={bg} alt="ai background" className="w-full h-full object-cover opacity-40 transition-opacity duration-1000" />
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4 pt-4">
+        {status && <div className="text-sm opacity-70 mb-2">{status}</div>}
+        <article className="prose prose-invert max-w-none bg-white/5 p-4 rounded-2xl min-h-[120px]">
+          <div dangerouslySetInnerHTML={{ __html: answer.replaceAll('\n', '<br/>') }} />
+        </article>
+
+        {confidence && (
+          <div className="mt-2 text-sm">Confidence: <span className="font-semibold">{confidence}</span></div>
+        )}
+
+        {!!cites.length && (
+          <aside className="mt-6 grid gap-3 sm:grid-cols-2">
+            {cites.map(c => (
+              <a key={c.id} href={c.url} target="_blank" rel="noreferrer" className="block bg-white/5 p-4 rounded-xl">
+                <div className="text-sm opacity-70">Source {c.id}</div>
+                <div className="font-semibold line-clamp-2">{c.title}</div>
+                {c.snippet && <div className="text-sm opacity-80 mt-1 line-clamp-3">{c.snippet}</div>}
+                {c.quote && <div className="text-xs opacity-70 mt-2 italic">“{c.quote}”</div>}
+              </a>
+            ))}
+          </aside>
+        )}
+      </div>
+
+      <form onSubmit={ask} className="fixed bottom-8 left-1/2 -translate-x-1/2 flex gap-2 w-full max-w-xl px-4">
         <input
           value={query}
-          onChange={(e)=>setQuery(e.target.value)}
+          onChange={(e) => setQuery(e.target.value)}
           className="flex-1 rounded-xl px-4 py-3 bg-white/10 outline-none"
           placeholder="Ask anything..."
         />
@@ -73,28 +108,6 @@ export default function Home() {
           Ask
         </button>
       </form>
-
-      {status && <div className="text-sm opacity-70 mb-2">{status}</div>}
-      <article className="prose prose-invert max-w-none bg-white/5 p-4 rounded-2xl min-h-[120px]">
-        <div dangerouslySetInnerHTML={{ __html: answer.replaceAll('\n','<br/>') }} />
-      </article>
-
-      {confidence && (
-        <div className="mt-2 text-sm">Confidence: <span className="font-semibold">{confidence}</span></div>
-      )}
-
-      {!!cites.length && (
-        <aside className="mt-6 grid gap-3 sm:grid-cols-2">
-          {cites.map(c => (
-            <a key={c.id} href={c.url} target="_blank" rel="noreferrer" className="block bg-white/5 p-4 rounded-xl">
-              <div className="text-sm opacity-70">Source {c.id}</div>
-              <div className="font-semibold line-clamp-2">{c.title}</div>
-              {c.snippet && <div className="text-sm opacity-80 mt-1 line-clamp-3">{c.snippet}</div>}
-              {c.quote && <div className="text-xs opacity-70 mt-2 italic">“{c.quote}”</div>}
-            </a>
-          ))}
-        </aside>
-      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Move search bar to a fixed bottom-center position with a rotating AI image background
- Remove layout width constraints to allow full-screen imagery
- Replace Gemini-based API with a simple Wikipedia-backed streaming endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afd5ea31b0832f8a3f7aa0eeea311f