### PR TITLE
feat: add case-insensitive wiki search with candidate suggestions

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -1,52 +1,156 @@
-// app/api/ask/route.ts
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-interface AskRequest { query: string; style?: 'simple' | 'expert'; }
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import type { Cite } from '../../../lib/types';
+import { wikiDisambiguate } from '../../../lib/wiki';
+import { searchCSE, findSocialLinks } from '../../../lib/tools/googleCSE';
 
-function enc(s: string) { return new TextEncoder().encode(s); }
-function sse(write: (s: string) => void) {
-  return (o: any) => write(`data: ${JSON.stringify(o)}\n\n`);
-}
-function rid() {
-  // @ts-ignore
-  return (globalThis.crypto?.randomUUID && globalThis.crypto.randomUUID()) || Math.random().toString(36).slice(2);
+const enc = (s: string) => new TextEncoder().encode(s);
+const sse = (write: (s: string) => void) => (o: any) => write(`data: ${JSON.stringify(o)}\n\n`);
+const rid = () => (globalThis as any).crypto?.randomUUID?.() || Math.random().toString(36).slice(2);
+const norm = (u: string) => { try { const x=new URL(u); x.hash=''; x.search=''; return x.toString(); } catch { return u; } };
+
+type RelatedItem = { label: string, prompt: string };
+
+function relatedQuestionsForPerson(name: string): RelatedItem[] {
+  // Template-based (fast & free); swap to Gemini-generated if you prefer.
+  return [
+    { label: 'Main achievements', prompt: `What are ${name}’s main achievements as Union Home Minister?` },
+    { label: 'Election strategy', prompt: `How did ${name} help BJP win key seats in Uttar Pradesh?` },
+    { label: 'Controversies', prompt: `What controversies or legal issues has ${name} faced during his career?` },
+    { label: 'Co-operation role', prompt: `How has ${name}’s role evolved since becoming Minister of Co-operation?` },
+    { label: 'Early influences', prompt: `How did ${name}’s early work with ABVP and RSS shape his politics?` },
+  ];
 }
 
 export async function POST(req: Request) {
-  const { query } = await req.json() as AskRequest;
+  const { query, style = 'simple' } = await req.json() as { query: string; style?: 'simple'|'expert' };
 
   const stream = new ReadableStream({
     async start(controller) {
-      const send = sse((s) => controller.enqueue(enc(s)));
-      send({ event: 'status', msg: 'searching Wikipedia' });
+      const send = sse((s)=>controller.enqueue(enc(s)));
+
       try {
-        const res = await fetch(`https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(query)}`);
-        if (res.ok) {
-          const data = await res.json();
-          const text = data.extract || 'No summary available.';
-          const cite = { id: '1', url: data.content_urls?.desktop?.page || '', title: data.title };
-          send({ event: 'token', text });
-          send({ event: 'cite', cite });
-          send({
-            event: 'final',
-            snapshot: { id: rid(), markdown: text, cites: [cite], timeline: [], confidence: 'medium' }
-          });
-        } else {
-          send({ event: 'status', msg: 'no results found' });
+        // 0) Disambiguate (like ChatGPT): primary + candidates
+        const { primary, others } = await wikiDisambiguate(query);
+
+        // Emit alternates so user can click a different one
+        if (others.length) {
+          send({ event: 'candidates', candidates: others.map(o => ({
+            title: o.title, description: o.description, image: o.image, url: o.pageUrl
+          }))});
         }
-      } catch (err: any) {
-        send({ event: 'status', msg: `error: ${err.message}` });
+
+        // If we have a primary Wikipedia profile, show the hero card immediately
+        if (primary) {
+          send({ event: 'profile', profile: {
+            title: primary.title, description: primary.description, extract: primary.extract,
+            image: primary.image, wikiUrl: primary.pageUrl
+          }});
+        }
+
+        // Also surface "Related" follow-ups (chips under the input)
+        const subjectName = primary?.title || query.trim();
+        send({ event: 'related', items: relatedQuestionsForPerson(subjectName) });
+
+        // 1) Build sources (socials + general CSE) using the resolved name
+        const [base, socials] = await Promise.all([
+          searchCSE(subjectName, 8),
+          findSocialLinks(subjectName)
+        ]);
+        const prelim: Cite[] = [];
+        const push = (c?: any) => c && prelim.push({ id: String(prelim.length + 1), url: c.url, title: c.title, snippet: c.snippet });
+        push(socials.wiki); push(socials.insta); push(socials.fb); push(socials.x);
+        base.forEach(push);
+
+        const seen = new Set<string>(); const cites: Cite[] = [];
+        for (const c of prelim) {
+          const k = norm(c.url);
+          if (!seen.has(k)) { seen.add(k); cites.push({ ...c, id: String(cites.length + 1) }); }
+          if (cites.length >= 10) break;
+        }
+        cites.forEach(c => send({ event: 'cite', cite: c }));
+
+        // 2) Stream the 200-word bio (like ChatGPT typing)
+        const apiKey = process.env.GEMINI_API_KEY;
+        if (!apiKey) throw new Error('GEMINI_API_KEY missing');
+
+        send({ event: 'status', msg: 'summarizing' });
+
+        const genAI = new GoogleGenerativeAI(apiKey);
+        const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash', tools: [{ googleSearch: {} }] } as any);
+
+        const sourceList = cites.map((c, i) => `[${i+1}] ${c.title} — ${c.url}`).join('\n');
+        const wikiExtract = primary?.extract ? `Wikipedia says:\n${primary.extract}\n` : '';
+        const sys = `You are Wizkid, a neutral, citation-first assistant.
+Write a concise PERSON BIO in <= 200 words (6–10 sentences). Use inline [n] citations matching the numbered sources. Prefer official sources.
+Style: ${style === 'expert' ? 'Expert' : 'Simple'}.`;
+
+        const prompt = `${sys}
+
+Subject: ${subjectName}
+
+Numbered sources:
+${sourceList}
+
+${wikiExtract}
+Instructions:
+- Start with identity + current role.
+- Add dated milestones and notable actions.
+- Keep <= 200 words. Use [n] citations.`;
+
+        let streamed = false;
+        const res = await model.generateContentStream({ contents: [{ role:'user', parts: [{ text: prompt }]}] });
+        for await (const ev of res.stream) {
+          const t = typeof (ev as any).text === 'function'
+            ? (ev as any).text()
+            : (ev as any)?.candidates?.[0]?.content?.parts?.map((p: any) => p.text).join('') || '';
+          if (t) { streamed = true; send({ event: 'token', text: t }); }
+        }
+
+        // Merge any Gemini-provided citations
+        try {
+          const full: any = await res.response;
+          const gm = full?.candidates?.[0]?.groundingMetadata;
+          const chunks = gm?.groundingChunks || [];
+          const extra = chunks.map((g: any) => {
+            const uri = g?.web?.uri || g?.retrievedContext?.uri;
+            const title = g?.web?.title || uri;
+            return uri ? { url: norm(uri), title } as Cite : null;
+          }).filter(Boolean) as Cite[];
+
+          const seen2 = new Set(cites.map(c => norm(c.url)));
+          for (const e of extra) {
+            const k = norm(e.url);
+            if (!seen2.has(k)) {
+              seen2.add(k);
+              const c = { ...e, id: String(seen2.size) };
+              send({ event: 'cite', cite: c });
+              cites.push(c);
+            }
+          }
+        } catch {}
+
+        // Fallback: if nothing streamed, at least show the wiki extract
+        if (!streamed && primary?.extract) send({ event: 'token', text: primary.extract.slice(0,1200) });
+
+        send({ event: 'final',
+          snapshot: { id: rid(), markdown: '(streamed)', cites, timeline: [], confidence: cites.length>=3?'high':(cites.length?'medium':'low') }
+        });
+      } catch (e: any) {
+        // Surface errors
+        const msg = e?.message || String(e);
+        const errId = rid();
+        send({ event: 'error', msg, id: errId });
+        send({ event: 'final', snapshot: { id: errId, markdown: msg, cites: [], timeline: [], confidence: 'low' } });
+      } finally {
+        controller.close();
       }
-      controller.close();
     }
   });
 
   return new Response(stream, {
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache, no-transform',
-      'Connection': 'keep-alive'
-    }
+    headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache, no-transform', 'Connection': 'keep-alive' }
   });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,58 +1,43 @@
 'use client';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
 
-type Cite = { id: string; url: string; title: string; snippet?: string; quote?: string; published_at?: string };
-type AskRequest = { query: string; style: 'simple' | 'expert' };
+type Cite = { id: string; url: string; title: string; snippet?: string };
+type Profile = { title?: string; description?: string; extract?: string; image?: string; wikiUrl?: string };
+type Candidate = { title: string; description?: string; image?: string; url: string };
+type RelatedItem = { label: string; prompt: string };
 
 export default function Home() {
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState('Amit Shah');
   const [answer, setAnswer] = useState('');
-  const [status, setStatus] = useState<string | undefined>();
+  const [status, setStatus] = useState<string|undefined>();
   const [cites, setCites] = useState<Cite[]>([]);
-  const [confidence, setConfidence] = useState<string | undefined>();
-  const abortRef = useRef<AbortController | null>(null);
-  const [bg, setBg] = useState('https://source.unsplash.com/1600x900/?ai');
+  const [profile, setProfile] = useState<Profile|undefined>();
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [related, setRelated] = useState<RelatedItem[]>([]);
+  const [confidence, setConfidence] = useState<string|undefined>();
+  const abortRef = useRef<AbortController|null>(null);
 
-  useEffect(() => {
-    const id = setInterval(() => {
-      setBg(`https://source.unsplash.com/1600x900/?ai&sig=${Date.now()}`);
-    }, 10000);
-    return () => clearInterval(id);
-  }, []);
+  async function ask(e?: React.FormEvent, qOverride?: string) {
+    if (e) e.preventDefault();
+    const q = qOverride ?? query;
 
-  async function ask(e: React.FormEvent) {
-    e.preventDefault();
-    setAnswer('');
-    setCites([]);
-    setConfidence(undefined);
-    setStatus('');
-    abortRef.current?.abort();
-    const ac = new AbortController();
-    abortRef.current = ac;
+    setAnswer(''); setCites([]); setConfidence(undefined);
+    setProfile(undefined); setCandidates([]); setRelated([]);
+    setStatus(''); abortRef.current?.abort();
 
-    const payload: AskRequest = { query, style: 'simple' };
+    const ac = new AbortController(); abortRef.current = ac;
     const resp = await fetch('/api/ask', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-      signal: ac.signal,
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: q, style: 'simple' }), signal: ac.signal,
     });
-
-    if (!resp.ok || !resp.body) {
-      setStatus('error');
-      return;
-    }
+    if (!resp.ok || !resp.body) { setStatus('error'); return; }
 
     const reader = resp.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = '';
-
+    const decoder = new TextDecoder(); let buffer = '';
     while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+      const { done, value } = await reader.read(); if (done) break;
       buffer += decoder.decode(value, { stream: true });
-      const parts = buffer.split('\n\n');
-      buffer = parts.pop() || '';
+      const parts = buffer.split('\n\n'); buffer = parts.pop() || '';
       for (const chunk of parts) {
         if (!chunk.startsWith('data:')) continue;
         const json = chunk.slice(5).trim();
@@ -60,54 +45,94 @@ export default function Home() {
           const evt = JSON.parse(json);
           if (evt.event === 'status') setStatus(evt.msg);
           if (evt.event === 'token') setAnswer(a => a + evt.text);
-          if (evt.event === 'cite') setCites(c => [...c, evt.cite]);
+          if (evt.event === 'cite') setCites(c => c.some(x => x.url === evt.cite.url) ? c : [...c, evt.cite]);
+          if (evt.event === 'profile') setProfile(evt.profile);
+          if (evt.event === 'candidates') setCandidates(evt.candidates || []);
+          if (evt.event === 'related') setRelated(evt.items || []);
+          if (evt.event === 'error') setStatus(`error: ${evt.msg}`);
           if (evt.event === 'final') setConfidence(evt.snapshot.confidence);
-        } catch { /* noop */ }
+        } catch {}
       }
     }
   }
 
   return (
-    <main className="relative min-h-screen pb-40">
-      <div className="absolute inset-x-0 top-0 h-1/2 -z-10 overflow-hidden">
-        <img src={bg} alt="ai background" className="w-full h-full object-cover opacity-40 transition-opacity duration-1000" />
-      </div>
-
-      <div className="max-w-4xl mx-auto px-4 pt-4">
-        {status && <div className="text-sm opacity-70 mb-2">{status}</div>}
-        <article className="prose prose-invert max-w-none bg-white/5 p-4 rounded-2xl min-h-[120px]">
-          <div dangerouslySetInnerHTML={{ __html: answer.replaceAll('\n', '<br/>') }} />
-        </article>
-
-        {confidence && (
-          <div className="mt-2 text-sm">Confidence: <span className="font-semibold">{confidence}</span></div>
-        )}
-
-        {!!cites.length && (
-          <aside className="mt-6 grid gap-3 sm:grid-cols-2">
-            {cites.map(c => (
-              <a key={c.id} href={c.url} target="_blank" rel="noreferrer" className="block bg-white/5 p-4 rounded-xl">
-                <div className="text-sm opacity-70">Source {c.id}</div>
-                <div className="font-semibold line-clamp-2">{c.title}</div>
-                {c.snippet && <div className="text-sm opacity-80 mt-1 line-clamp-3">{c.snippet}</div>}
-                {c.quote && <div className="text-xs opacity-70 mt-2 italic">“{c.quote}”</div>}
-              </a>
-            ))}
-          </aside>
-        )}
-      </div>
-
-      <form onSubmit={ask} className="fixed bottom-8 left-1/2 -translate-x-1/2 flex gap-2 w-full max-w-xl px-4">
+    <main>
+      <h1 className="text-3xl font-bold mb-4">Wizkid</h1>
+      <form onSubmit={ask} className="flex gap-2 mb-4">
         <input
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e)=>setQuery(e.target.value)}
           className="flex-1 rounded-xl px-4 py-3 bg-white/10 outline-none"
-          placeholder="Ask anything..."
+          placeholder="Ask about a person, e.g. 'Amit Shah'"
         />
         <button className="px-5 py-3 rounded-xl bg-white/20 hover:bg-white/30" type="submit">
           Ask
         </button>
       </form>
+
+      {/* Did you mean… (alternates) */}
+      {candidates.length > 0 && (
+        <div className="mb-3">
+          <div className="text-sm opacity-80 mb-1">Did you mean:</div>
+          <div className="flex flex-wrap gap-2">
+            {candidates.map(c => (
+              <button key={c.title}
+                onClick={() => { setQuery(c.title); ask(undefined, c.title); }}
+                className="px-3 py-2 bg-white/10 rounded-xl hover:bg-white/20">
+                {c.title}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Hero */}
+      {(profile?.image || profile?.title) && (
+        <section className="flex items-center gap-4 mb-3">
+          {profile?.image && <img src={profile.image} alt={profile?.title || 'profile'} className="w-16 h-16 rounded-xl object-cover" />}
+          <div>
+            <div className="text-xl font-semibold">{profile?.title || query}</div>
+            {profile?.description && <div className="text-sm opacity-80">{profile.description}</div>}
+          </div>
+        </section>
+      )}
+
+      {/* Streaming summary */}
+      <article className="prose prose-invert max-w-none bg-white/5 p-4 rounded-2xl min-h-[140px]">
+        {status && <div className="text-xs opacity-70 mb-2">{status}</div>}
+        <div dangerouslySetInnerHTML={{ __html: (answer || '').replaceAll('\n','<br/>') }} />
+        {confidence && <div className="mt-3 text-sm">Confidence: <span className="font-semibold">{confidence}</span></div>}
+      </article>
+
+      {/* Related questions */}
+      {related.length > 0 && (
+        <div className="mt-3">
+          <div className="text-sm opacity-80 mb-1">Related</div>
+          <div className="flex flex-wrap gap-2">
+            {related.map(r => (
+              <button key={r.prompt}
+                onClick={() => { setQuery(r.prompt); ask(undefined, r.prompt); }}
+                className="px-3 py-2 bg-white/10 rounded-xl hover:bg-white/20">
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Sources grid */}
+      {!!cites.length && (
+        <aside className="mt-6 grid gap-3 sm:grid-cols-2">
+          {cites.map(c => (
+            <a key={c.id} href={c.url} target="_blank" rel="noreferrer" className="block bg-white/5 p-4 rounded-xl">
+              <div className="text-sm opacity-70">Source {c.id}</div>
+              <div className="font-semibold line-clamp-2">{c.title}</div>
+              {c.snippet && <div className="text-sm opacity-80 mt-1 line-clamp-3">{c.snippet}</div>}
+            </a>
+          ))}
+        </aside>
+      )}
     </main>
   );
 }

--- a/lib/tools/googleCSE.ts
+++ b/lib/tools/googleCSE.ts
@@ -1,0 +1,25 @@
+import { SearchResult } from '../types';
+
+const API = 'https://www.googleapis.com/customsearch/v1';
+const key = process.env.GOOGLE_CSE_API_KEY;
+const cx = process.env.GOOGLE_CSE_CX;
+
+export async function searchCSE(q: string, n = 5): Promise<SearchResult[]> {
+  if (!key || !cx) return [];
+  const params = new URLSearchParams({ q, key, cx, num: String(n) });
+  const url = `${API}?${params.toString()}`;
+  const r = await fetch(url, { cache: 'no-store' });
+  if (!r.ok) return [];
+  const j: any = await r.json();
+  return (j.items || []).map((it: any) => ({ url: it.link, title: it.title, snippet: it.snippet }));
+}
+
+export async function findSocialLinks(name: string): Promise<{ wiki?: SearchResult; insta?: SearchResult; fb?: SearchResult; x?: SearchResult; }> {
+  const [wiki, insta, fb, x] = await Promise.all([
+    searchCSE(`${name} site:wikipedia.org`, 1),
+    searchCSE(`${name} site:instagram.com`, 1),
+    searchCSE(`${name} site:facebook.com`, 1),
+    searchCSE(`${name} site:twitter.com OR site:x.com`, 1)
+  ]);
+  return { wiki: wiki[0], insta: insta[0], fb: fb[0], x: x[0] };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,12 @@
+export type Cite = {
+  id: string;
+  url: string;
+  title: string;
+  snippet?: string;
+};
+
+export type SearchResult = {
+  url: string;
+  title: string;
+  snippet?: string;
+};

--- a/lib/wiki.ts
+++ b/lib/wiki.ts
@@ -1,0 +1,64 @@
+export type WikiProfile = {
+  title: string;
+  description?: string;
+  extract?: string;
+  pageUrl?: string;
+  image?: string;
+};
+
+export type WikiCandidate = {
+  title: string;
+  description?: string;
+  pageUrl: string;
+  image?: string;
+};
+
+function wikiPageUrl(title: string) {
+  const t = encodeURIComponent(title.replace(/\s/g, '_'));
+  return `https://en.wikipedia.org/wiki/${t}`;
+}
+
+async function fetchSummaryByTitle(title: string): Promise<WikiProfile | null> {
+  const t = encodeURIComponent(title);
+  const url = `https://en.wikipedia.org/api/rest_v1/page/summary/${t}?redirect=true`;
+  const r = await fetch(url, { next: { revalidate: 3600 } });
+  if (!r.ok) return null;
+  const j: any = await r.json();
+  return {
+    title: j.title,
+    description: j.description,
+    extract: j.extract,
+    pageUrl: j.content_urls?.desktop?.page || wikiPageUrl(j.title),
+    image: j.originalimage?.source || j.thumbnail?.source
+  };
+}
+
+/** Find up to N candidates for a query (case-insensitive). */
+export async function searchWikiCandidates(q: string, n = 6): Promise<WikiCandidate[]> {
+  const api = `https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=${encodeURIComponent(q)}&format=json&srlimit=${n}&utf8=1&origin=*`;
+  const r = await fetch(api, { cache: 'no-store' });
+  if (!r.ok) return [];
+  const j: any = await r.json();
+  const titles: string[] = (j?.query?.search || []).map((s: any) => s.title);
+  // Enrich with summary (gets short description & a thumbnail if available)
+  const enriched = await Promise.all(titles.map(async (t) => {
+    const s = await fetchSummaryByTitle(t);
+    return {
+      title: t,
+      description: s?.description,
+      pageUrl: s?.pageUrl || wikiPageUrl(t),
+      image: s?.image
+    } as WikiCandidate;
+  }));
+  return enriched;
+}
+
+/** Get a rich primary profile (image + extract), with other candidates. */
+export async function wikiDisambiguate(q: string): Promise<{ primary: WikiProfile | null; others: WikiCandidate[] }> {
+  // Try search first so we’re case-insensitive and can list alternates
+  const cands = await searchWikiCandidates(q, 6);
+  const primaryTitle = cands[0]?.title;
+  const primary = primaryTitle ? await fetchSummaryByTitle(primaryTitle) : null;
+  const others = cands.slice(1);
+  return { primary, others };
+}


### PR DESCRIPTION
## Summary
- add wikipedia disambiguation utilities and search helpers
- stream bios with related question chips and alternate suggestions
- update UI to show hero profile, "Did you mean" candidates, related chips, and sources

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afed59b0c8832fac47ea5c97bb3ab7