### PR TITLE
feat: add debug API route

### DIFF
--- a/app/api/debug/route.ts
+++ b/app/api/debug/route.ts
@@ -1,0 +1,10 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return Response.json({
+    GEMINI_API_KEY: !!process.env.GEMINI_API_KEY,
+    GOOGLE_CSE_ID: !!process.env.GOOGLE_CSE_ID,
+    GOOGLE_CSE_KEY: !!process.env.GOOGLE_CSE_KEY,
+  });
+}


### PR DESCRIPTION
## Summary
- add `/api/debug` endpoint reporting presence of GEMINI and Google CSE env vars

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `curl -s http://localhost:3000/api/debug`


------
https://chatgpt.com/codex/tasks/task_e_68aff0234d2c832fa0a12b821ae08d18