### PR TITLE
docs: add search and LLM key placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 GEMINI_API_KEY=your_gemini_key
 GOOGLE_CSE_ID=your_cse_id
 GOOGLE_CSE_KEY=your_cse_key
+SEARCH_API_KEY=your_search_api_key
+LLM_API_KEY=your_llm_api_key

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `style` field is optional and may be `simple` or `expert` (defaults to `simp
 
 ## Run locally
 ```bash
-cp .env.example .env # set GEMINI_API_KEY, GOOGLE_CSE_ID, and GOOGLE_CSE_KEY
+cp .env.example .env # set GEMINI_API_KEY, GOOGLE_CSE_ID, GOOGLE_CSE_KEY, SEARCH_API_KEY, and LLM_API_KEY
 npm install
 npm run dev
 # open http://localhost:3000


### PR DESCRIPTION
## Summary
- document SEARCH_API_KEY and LLM_API_KEY in env example
- note new env vars in README setup instructions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68affafd7cb4832f956237bf76510696