### PR TITLE
chore: fix type setup for Node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "next": "14.2.5",
@@ -15,6 +16,8 @@
   "devDependencies": {
     "typescript": "^5.5.4",
     "@types/node": "^20.12.12",
+    "@types/express": "^4.17.21",
+    "@types/cors": "^2.8.17",
     "@types/react": "^18.3.3",
     "tailwindcss": "^3.4.10",
     "postcss": "^8.4.41",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,12 +17,20 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": ".",
-    "paths": {}
+    "paths": {},
+    "types": ["node"],
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- add missing type packages for express/cors and typecheck script
- ensure tsconfig uses node typings and interop/skiplibrary for Node 20

## Testing
- `npm run typecheck`
- `npm run build`
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b00bfc53b8832fb94f92cee2fad546