### PR TITLE
fix: remove env injection and keep search URLs intact

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 SEARCH_API_KEY=your_search_api_key_here
 LLM_API_KEY=your_llm_api_key_here
 
+GEMINI_API_KEY=dummy
+GOOGLE_CSE_ID=dummy
+GOOGLE_CSE_KEY=dummy

--- a/lib/tools/googleCSE.ts
+++ b/lib/tools/googleCSE.ts
@@ -2,7 +2,7 @@
 import type { SearchResult } from '../types';
 
 function domainOf(u: string) { try { return new URL(u).hostname.replace(/^www\./,''); } catch { return ''; } }
-function normalize(u: string) { try { const x=new URL(u); x.hash=''; x.search=''; return x.toString(); } catch { return u; } }
+function normalize(u: string) { try { const x=new URL(u); x.hash=''; return x.toString(); } catch { return u; } }
 
 export async function searchCSE(q: string, num = 6): Promise<SearchResult[]> {
   const key = process.env.GOOGLE_CSE_KEY, cx = process.env.GOOGLE_CSE_ID;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,11 +2,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: { serverActions: {} },
-  env: {
-    GEMINI_API_KEY: process.env.GEMINI_API_KEY || "dummy",
-    GOOGLE_CSE_ID: process.env.GOOGLE_CSE_ID || "dummy",
-    GOOGLE_CSE_KEY: process.env.GOOGLE_CSE_KEY || "dummy"
-  }
+  experimental: { serverActions: {} }
 };
 export default nextConfig;


### PR DESCRIPTION
## Summary
- avoid embedding API keys by removing env block from next config
- keep Google CSE result query strings by softening normalization
- document dummy API keys for CI builds

## Testing
- `npm ci`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0152284d0832fae8deab09fa83230