### PR TITLE
fix: add dummy env vars for CI builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 SEARCH_API_KEY=""
 LLM_API_KEY=""
+GEMINI_API_KEY="dummy"
+GOOGLE_CSE_ID="dummy"
+GOOGLE_CSE_KEY="dummy"


### PR DESCRIPTION
## Summary
- add dummy GEMINI_API_KEY, GOOGLE_CSE_ID, and GOOGLE_CSE_KEY to `.env.example` so CI builds have safe defaults

## Testing
- `npm ci` *(fails: Missing package-lock.json)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b015435ff4832f860321127ac159ab