### PR TITLE
Add viewport metadata for responsive layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,11 @@
 import './globals.css';
+import type { Metadata, Viewport } from 'next';
 
-export const metadata = { title: 'Wizkid' };
+export const metadata: Metadata = { title: 'Wizkid' };
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
## Summary
- ensure mobile responsiveness by adding viewport metadata in the root layout

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b017b62f8c832fa0734f5d42183cbf