### PR TITLE
fix: reliable person matching & safe disambiguation (no random picks)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState, useRef, useMemo } from 'react';
+import Link from 'next/link';
 
 type Cite = { id: string; url: string; title: string; snippet?: string };
 type Profile = { title?: string; description?: string; extract?: string; image?: string; wikiUrl?: string };
@@ -7,7 +8,7 @@ type Candidate = { title: string; description?: string; image?: string; url: str
 type RelatedItem = { label: string; prompt: string };
 
 export default function Home() {
-  const [query, setQuery] = useState('Amit Shah');
+  const [query, setQuery] = useState('');
   const [subject, setSubject] = useState<string|undefined>();
   const [answer, setAnswer] = useState('');
   const [status, setStatus] = useState<string|undefined>();
@@ -77,7 +78,7 @@ export default function Home() {
 
   return (
     <main className="max-w-3xl mx-auto p-4">
-      <h1 className="text-3xl font-bold mb-4">Wizkid</h1>
+      <h1 className="text-3xl font-bold mb-4"><Link href="/">Wizkid</Link></h1>
       <form onSubmit={ask} className="flex gap-2 mb-4">
         <input
           value={query}
@@ -105,7 +106,13 @@ export default function Home() {
         </div>
       )}
 
-      {(profile?.image || profile?.title) && (
+      {!profile && candidates.length > 0 && (
+        <div className="mb-3 text-sm opacity-80">
+          Multiple matches found — please pick the right profile above.
+        </div>
+      )}
+
+      {profile && (
         <section className="flex items-center gap-4 mb-2">
           {profile?.image && <img src={profile.image} alt={profile?.title || 'profile'} className="w-16 h-16 rounded-xl object-cover" />}
           <div>
@@ -122,11 +129,13 @@ export default function Home() {
         </section>
       )}
 
-      <article className="prose prose-invert max-w-none bg-white/5 p-4 rounded-2xl min-h-[140px]">
-        {status && <div className="text-xs opacity-70 mb-2">{status}</div>}
-        <div dangerouslySetInnerHTML={{ __html: (answer || '').replaceAll('\n','<br/>') }} />
-        {confidence && <div className="mt-3 text-sm">Confidence: <span className="font-semibold">{confidence}</span></div>}
-      </article>
+      {profile && (
+        <article className="prose prose-invert max-w-none bg-white/5 p-4 rounded-2xl min-h-[140px]">
+          {status && <div className="text-xs opacity-70 mb-2">{status}</div>}
+          <div dangerouslySetInnerHTML={{ __html: (answer || '').replaceAll('\n','<br/>') }} />
+          {confidence && <div className="mt-3 text-sm">Confidence: <span className="font-semibold">{confidence}</span></div>}
+        </article>
+      )}
 
       {related.length > 0 && (
         <div className="mt-3">
@@ -162,4 +171,3 @@ export default function Home() {
     </main>
   );
 }
-

--- a/lib/people/cseCandidates.ts
+++ b/lib/people/cseCandidates.ts
@@ -1,0 +1,45 @@
+import { searchCSE } from '../tools/googleCSE';
+import { fetchOpenGraph } from '../tools/opengraph';
+
+export type CSERawCand = { name: string; url: string; image?: string; source: 'linkedin'|'instagram'|'facebook'|'x'|'twitter'|'web' };
+
+function extractNameFromTitle(title: string): string {
+  // Common patterns: "Name - Title | LinkedIn", "Name | LinkedIn", "Name (@handle) • Instagram"
+  const t = title.replace(/\u2013|\u2014/g, '-');
+  const ig = t.match(/^(.+?)\s*\(@/i);
+  if (ig) return ig[1].trim();
+  const li = t.match(/^(.+?)[\-|–]/);
+  if (li) return li[1].trim();
+  return t.replace(/\s*\|\s*LinkedIn/i, '').replace(/\s*•\s*Instagram/i, '').trim();
+}
+
+export async function csePeopleCandidates(q: string, perHost = 4): Promise<CSERawCand[]> {
+  const queries = [
+    `site:linkedin.com/in "${q}"`,
+    `site:instagram.com "${q}"`,
+    `site:facebook.com "${q}"`,
+    `site:x.com "${q}"`,
+    `site:twitter.com "${q}"`
+  ];
+  const flat = (await Promise.all(queries.map(x => searchCSE(x, perHost)))).flat();
+
+  const out: CSERawCand[] = [];
+  for (const r of flat) {
+    const host = (r.domain || '').toLowerCase();
+    let source: CSERawCand['source'] = 'web';
+    if (host.endsWith('linkedin.com') && /\/in\//.test(r.url)) source = 'linkedin';
+    else if (host.endsWith('instagram.com')) source = 'instagram';
+    else if (host.endsWith('facebook.com')) source = 'facebook';
+    else if (host.endsWith('x.com') || host.endsWith('twitter.com')) source = 'x';
+
+    const name = extractNameFromTitle(r.title || '');
+    const cand: CSERawCand = { name: name || q, url: r.url, source };
+
+    // Try OG image for nicer chips
+    try {
+      if (!cand.image) cand.image = (await fetchOpenGraph(r.url))?.image;
+    } catch {}
+    out.push(cand);
+  }
+  return out;
+}

--- a/lib/text/similarity.ts
+++ b/lib/text/similarity.ts
@@ -1,0 +1,41 @@
+export function normalizeName(s: string) {
+  return s
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function tokenSet(s: string): Set<string> {
+  return new Set(normalizeName(s).split(' ').filter(Boolean));
+}
+
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (!a.size && !b.size) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return inter / (a.size + b.size - inter || 1);
+}
+
+/**
+ * Simple name score:
+ * 1.0 for exact normalized equality
+ * otherwise 0..1 by Jaccard token overlap with small prefix bonus.
+ */
+export function nameScore(query: string, candidate: string): number {
+  const qn = normalizeName(query);
+  const cn = normalizeName(candidate);
+  if (!qn || !cn) return 0;
+  if (qn === cn) return 1;
+  const jq = jaccard(tokenSet(qn), tokenSet(cn));
+  const prefixBonus = cn.startsWith(qn) || qn.startsWith(cn) ? 0.15 : 0;
+  return Math.min(1, jq + prefixBonus);
+}
+
+/** Confident if exact or very high similarity. */
+export function isConfidentMatch(query: string, candidate: string) {
+  const s = nameScore(query, candidate);
+  return s >= 0.90;
+}


### PR DESCRIPTION
## Summary
- add name similarity scoring utilities and CSE-based people candidate gathering
- improve person discovery to rank by name similarity and only auto-select when confident
- update ask API to stop when multiple matches, stitch fallback summary, and tweak UI for disambiguation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b02adc9c1c832f8780d5593d47f413