### PR TITLE
Wizkid v3.2 – fix empty-sources LLM call, stronger “near me”, CSE fallback for unknown people

### DIFF
--- a/lib/intent.ts
+++ b/lib/intent.ts
@@ -1,10 +1,21 @@
-export type IntentKind = 'people' | 'local' | 'company' | 'general';
+export type Intent = 'people' | 'company' | 'local' | 'general';
 
-export function detectIntent(q: string): IntentKind {
-  const s = q.toLowerCase().trim();
-  if (/\bnear me\b/.test(s) || /\bnearby\b/.test(s)) return 'local';
-  if (/\bprivate limited\b|\bpvt ltd\b|\blimited\b|\binc\b|\bllc\b|\bltd\b/.test(s)) return 'company';
-  // crude person heuristic: 2 tokens, each capitalized or namey words
-  if (/^[a-z ]+$/i.test(q) && q.trim().split(/\s+/).length <= 4 && /[a-z]/i.test(q)) return 'people';
+export function detectIntent(q: string): Intent {
+  const s = q.trim().toLowerCase();
+
+  // strong "near me" detector
+  const nearPhrase = /\b(near\s*me|nearby|around\s*me|close\s*by|in\s+my\s+area)\b/;
+  const localTerms = /\b(doctor|clinic|hospital|dentist|pharmacy|restaurant|cafe|coffee|bank|atm|lawyer|attorney|advocate|property|notary|plumber|electrician|repair|hotel|gym|school|university|salon|barber|grocery|supermarket|store|chemist)\b/;
+
+  if (nearPhrase.test(s)) return 'local';
+  if (localTerms.test(s) && /\b(near|nearby|around|close|me|in)\b/.test(s)) return 'local';
+
+  if (/\bwho\s+is\b/.test(s)) return 'people';
+
+  const words = s.split(/\s+/);
+  if (words.length <= 4 && /^[a-z .'-]+$/.test(s)) return 'people';
+
+  if (/\b(ltd|limited|inc|llc|plc|pvt|private|company|corp|co\.|enterprises)\b/.test(s)) return 'company';
+
   return 'general';
 }


### PR DESCRIPTION
## Summary
- broaden local intent detection with enhanced near-me heuristics
- fetch one-shot coordinates when location is enabled on the client
- avoid empty-source LLM calls by broadening search and building prompts conditionally

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b051032ca0832fb1dca76e294f6466