### PR TITLE
feat: add Wizkid web app with auto LLM search

### DIFF
--- a/apps/web/app/api/ask/route.ts
+++ b/apps/web/app/api/ask/route.ts
@@ -1,0 +1,77 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { planAndFetch } from '../../../lib/think/orchestrator';
+import { summarizeWithCitations, relatedSuggestions } from '../../../lib/llm/tasks';
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const sse = (write: (s: string) => void) => (o: any) => write(`data: ${JSON.stringify(o)}\n\n`);
+const rid = () => (globalThis as any).crypto?.randomUUID?.() || Math.random().toString(36).slice(2);
+async function streamPlain(send:(o:any)=>void, text:string){ if (!text) return; for (const ch of (text.match(/.{1,110}(\s|$)/g) || [text])) send({event:'token', text: ch}); }
+
+type Req = { query: string; coords?: { lat:number, lon:number } };
+
+export async function POST(req: Request) {
+  const { query, coords } = await req.json() as Req;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = sse((s)=>controller.enqueue(enc(s)));
+      try {
+        if (!query?.trim()) { send({event:'final', snapshot:{ id: rid(), markdown:'(empty query)', cites:[], timeline:[], confidence:'low' }}); controller.close(); return; }
+
+        const plan = await planAndFetch(query, coords);
+        if (plan.candidates?.length) send({ event:'candidates', candidates: plan.candidates });
+        if (plan.status) send({ event:'status', msg: plan.status });
+        if (plan.plan?.needLocation) { await streamPlain(send,'Please allow location to search near you.'); send({ event:'final', snapshot:{ id: rid(), markdown:'(need location)', cites:[], timeline:[], confidence:'low' } }); controller.close(); return; }
+
+        // Hero (people)
+        if (plan.profile) {
+          send({ event:'profile', profile: { title: plan.profile.title, description: plan.profile.description, extract: plan.profile.extract, image: plan.profile.image, wikiUrl: plan.profile.pageUrl } });
+        }
+
+        // Places (local)
+        if (plan.places?.length) {
+          send({ event:'places', places: plan.places });
+          await streamPlain(send, `Found ${plan.places.length} places. Showing the closest first.`);
+          send({ event:'final', snapshot:{ id: rid(), markdown:'(streamed)', cites:[], timeline:[], confidence: plan.places.length ? 'medium' : 'low' } });
+          controller.close(); return;
+        }
+
+        // Sources
+        const cites = plan.cites || [];
+        for (const c of cites) send({ event:'cite', cite: c });
+
+        // Related chips
+        const subj = plan.profile?.title || plan.plan.subject || query.trim();
+        relatedSuggestions(subj).then(items => send({ event:'related', items })).catch(()=>{});
+
+        // Summarize (only if we have some sources)
+        if (!cites.length) {
+          const missing: string[] = [];
+          if (!process.env.GOOGLE_CSE_ID || !process.env.GOOGLE_CSE_KEY) missing.push('Google CSE');
+          if (!process.env.GEMINI_API_KEY && !process.env.OPENAI_API_KEY) missing.push('LLM provider');
+          await streamPlain(send, `No sources yet — broadening web search or keys missing (${missing.join(', ') || 'none'}).`);
+          send({ event:'final', snapshot:{ id: rid(), markdown:'(no sources)', cites:[], timeline:[], confidence:'low' } });
+          controller.close(); return;
+        }
+
+        const text = await summarizeWithCitations({
+          subject: subj,
+          sources: cites.map((c)=>({ title:c.title, url:c.url })),
+          style: "simple"
+        });
+        await streamPlain(send, text);
+
+        const conf = cites.length >= 3 ? 'high' : (cites.length ? 'medium' : 'low');
+        send({ event:'final', snapshot:{ id: rid(), markdown:'(streamed)', cites, timeline:[], confidence: conf } });
+      } catch (e:any) {
+        const msg=e?.message || String(e);
+        sse((s)=>controller.enqueue(enc(s)))({ event:'error', msg });
+        sse((s)=>controller.enqueue(enc(s)))({ event:'final', snapshot:{ id: rid(), markdown: msg, cites:[], timeline:[], confidence:'low' } });
+      } finally { controller.close(); }
+    }
+  });
+
+  return new Response(stream, { headers: { 'Content-Type':'text/event-stream', 'Cache-Control':'no-cache, no-transform', 'Connection':'keep-alive' } });
+}

--- a/apps/web/app/api/debug/route.ts
+++ b/apps/web/app/api/debug/route.ts
@@ -1,0 +1,14 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return Response.json({
+    GOOGLE_CSE_ID: !!process.env.GOOGLE_CSE_ID,
+    GOOGLE_CSE_KEY: !!process.env.GOOGLE_CSE_KEY,
+    GEOAPIFY_KEY: !!process.env.GEOAPIFY_KEY,
+    OPENAI_API_KEY: !!process.env.OPENAI_API_KEY,
+    OPENAI_MODEL: process.env.OPENAI_MODEL || null,
+    GEMINI_API_KEY: !!process.env.GEMINI_API_KEY,
+    UPSTASH_REDIS: !!process.env.UPSTASH_REDIS_REST_URL && !!process.env.UPSTASH_REDIS_REST_TOKEN
+  });
+}

--- a/apps/web/app/api/feedback/route.ts
+++ b/apps/web/app/api/feedback/route.ts
@@ -1,0 +1,22 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(()=>({}));
+  const { query, helpful, reason } = body || {};
+  const payload = { ts: Date.now(), query, helpful: !!helpful, reason: reason || null };
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (url && token) {
+    try {
+      await fetch(`${url}/hset/wizkid:feedback:${Date.now()}`, {
+        method:'POST', headers:{ Authorization:`Bearer ${token}`, 'Content-Type':'application/json' },
+        body: JSON.stringify(payload)
+      });
+      return Response.json({ ok: true, stored: 'redis' });
+    } catch {}
+  }
+  console.log('FEEDBACK', payload); // fallback
+  return Response.json({ ok: true, stored: 'console' });
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,6 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root { color-scheme: dark; }
+body { @apply bg-neutral-900 text-neutral-100; }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,183 @@
+'use client';
+import { useRef, useState } from 'react';
+
+type Cite = { id: string; url: string; title: string; snippet?: string };
+type Profile = { title?: string; description?: string; extract?: string; image?: string; wikiUrl?: string };
+type Candidate = { title: string; description?: string; image?: string; url?: string; pageUrl?: string };
+type RelatedItem = { label: string; prompt: string };
+type Place = { id:string; name:string; address?:string; distance_m?:number; phone?:string; website?:string; osmUrl?:string; source:'geoapify'|'osm' };
+
+export default function Page() {
+  const [query, setQuery] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [status, setStatus] = useState<string|undefined>();
+  const [cites, setCites] = useState<Cite[]>([]);
+  const [profile, setProfile] = useState<Profile|undefined>();
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [related, setRelated] = useState<RelatedItem[]>([]);
+  const [places, setPlaces] = useState<Place[]>([]);
+  const [confidence, setConfidence] = useState<string|undefined>();
+  const [coords, setCoords] = useState<{lat:number,lon:number}|undefined>();
+  const abortRef = useRef<AbortController|null>(null);
+
+  function ask(e?: React.FormEvent) {
+    if (e) e.preventDefault();
+    setAnswer(''); setCites([]); setConfidence(undefined);
+    setProfile(undefined); setCandidates([]); setRelated([]); setPlaces([]);
+    setStatus(''); abortRef.current?.abort();
+
+    const ac = new AbortController(); abortRef.current = ac;
+    fetch('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, coords }),
+      signal: ac.signal
+    }).then(resp => {
+      if (!resp.ok || !resp.body) { setStatus('error'); return; }
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder(); let buffer = '';
+      (async function read() {
+        const { done, value } = await reader.read(); if (done) return;
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split('\n\n'); buffer = parts.pop() || '';
+        for (const chunk of parts) {
+          if (!chunk.startsWith('data:')) continue;
+          const json = chunk.slice(5).trim();
+          try {
+            const evt = JSON.parse(json);
+            if (evt.event === 'status') setStatus(evt.msg);
+            if (evt.event === 'token') setAnswer(a => a + evt.text);
+            if (evt.event === 'cite') setCites(c => c.some(x => x.url === evt.cite.url) ? c : [...c, evt.cite]);
+            if (evt.event === 'profile') setProfile(evt.profile);
+            if (evt.event === 'candidates') setCandidates(evt.candidates || []);
+            if (evt.event === 'related') setRelated(evt.items || []);
+            if (evt.event === 'places') setPlaces(evt.places || []);
+            if (evt.event === 'error') setStatus(`error: ${evt.msg}`);
+            if (evt.event === 'final') setConfidence(evt.snapshot.confidence);
+          } catch {}
+        }
+        read();
+      })();
+    });
+  }
+
+  function useLocation() {
+    navigator.geolocation.getCurrentPosition(
+      (pos)=> setCoords({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
+      ()=> setCoords(undefined),
+      { enableHighAccuracy:true, timeout: 7000 }
+    );
+  }
+
+  function sendFeedback(ok:boolean) {
+    fetch('/api/feedback', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ query, helpful: ok })});
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl p-5">
+      <header className="flex items-center justify-between mb-4">
+        <button onClick={()=>window.location.reload()} className="text-2xl font-bold">Wizkid</button>
+        <div className="flex gap-2">
+          <button onClick={useLocation} className="px-3 py-1 rounded bg-white/10 hover:bg-white/20">Location ✓</button>
+        </div>
+      </header>
+
+      <form onSubmit={ask} className="flex gap-2 mb-4">
+        <input
+          value={query}
+          onChange={(e)=>setQuery(e.target.value)}
+          className="flex-1 rounded-xl px-4 py-3 bg-white/10 outline-none"
+          placeholder="Ask anything (e.g., “property lawyer near me”)"
+        />
+        <button className="px-5 py-3 rounded-xl bg-white/20 hover:bg-white/30" type="submit">
+          Search
+        </button>
+      </form>
+
+      {/* Did you mean… */}
+      {candidates.length > 0 && (
+        <div className="mb-3">
+          <div className="text-sm opacity-80 mb-1">Did you mean:</div>
+          <div className="flex flex-wrap gap-2">
+            {candidates.map(c => (
+              <button key={c.title}
+                onClick={() => { setQuery(c.title); ask(); }}
+                className="px-3 py-2 bg-white/10 rounded-xl hover:bg-white/20">
+                {c.title}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Hero */}
+      {(profile?.image || profile?.title) && (
+        <section className="flex items-center gap-4 mb-3">
+          {profile?.image && <img src={profile.image} alt={profile?.title || 'profile'} className="w-16 h-16 rounded-xl object-cover" />}
+          <div>
+            <div className="text-xl font-semibold">{profile?.title}</div>
+            {profile?.description && <div className="text-sm opacity-80">{profile.description}</div>}
+          </div>
+        </section>
+      )}
+
+      {/* Streaming answer */}
+      <article className="prose prose-invert max-w-none bg-white/5 p-4 rounded-2xl min-h-[140px]">
+        {status && <div className="text-xs opacity-70 mb-2">{status}</div>}
+        <div dangerouslySetInnerHTML={{ __html: (answer || '').replaceAll('\n','<br/>') }} />
+        {confidence && (
+          <div className="mt-3 flex items-center gap-3 text-sm">
+            Confidence: <span className="font-semibold">{confidence}</span>
+            <button onClick={()=>sendFeedback(true)} className="px-2 py-1 rounded bg-white/10 hover:bg-white/20">👍</button>
+            <button onClick={()=>sendFeedback(false)} className="px-2 py-1 rounded bg-white/10 hover:bg-white/20">👎</button>
+          </div>
+        )}
+      </article>
+
+      {/* Places */}
+      {!!places.length && (
+        <div className="mt-4 grid gap-2">
+          {places.map(p=>(
+            <div key={p.id} className="bg-white/5 p-3 rounded-xl">
+              <div className="font-semibold">{p.name}</div>
+              {p.address && <div className="text-sm opacity-80">{p.address}</div>}
+              <div className="text-xs opacity-70">
+                {p.distance_m ? `${p.distance_m} m · ` : ''}{p.website ? <a className="underline" target="_blank" href={p.website}>Website</a> : null}
+                {p.osmUrl ? <> · <a className="underline" target="_blank" href={p.osmUrl}>OpenStreetMap</a></> : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Related */}
+      {related.length > 0 && (
+        <div className="mt-3">
+          <div className="text-sm opacity-80 mb-1">Related</div>
+          <div className="flex flex-wrap gap-2">
+            {related.map(r => (
+              <button key={r.prompt}
+                onClick={() => { setQuery(r.prompt); ask(); }}
+                className="px-3 py-2 bg-white/10 rounded-xl hover:bg-white/20">
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Sources */}
+      {!!cites.length && (
+        <aside className="mt-6 grid gap-3 sm:grid-cols-2">
+          {cites.map(c => (
+            <a key={c.id} href={c.url} target="_blank" rel="noreferrer" className="block bg-white/5 p-4 rounded-xl">
+              <div className="text-sm opacity-70">Source {c.id}</div>
+              <div className="font-semibold line-clamp-2">{c.title}</div>
+              {c.snippet && <div className="text-sm opacity-80 mt-1 line-clamp-3">{c.snippet}</div>}
+            </a>
+          ))}
+        </aside>
+      )}
+    </main>
+  );
+}

--- a/apps/web/lib/intent.ts
+++ b/apps/web/lib/intent.ts
@@ -1,0 +1,12 @@
+export type Intent = 'people' | 'company' | 'local' | 'general';
+
+export function detectIntent(q: string): Intent {
+  const s = q.trim().toLowerCase();
+  if (/\bnear\s*me\b|\bnearby\b/.test(s)) return 'local';
+  if (/\b(doctor|clinic|hospital|dentist|pharmacy|restaurant|cafe|bank|atm|lawyer|attorney|advocate|property)\b/.test(s) && /\b(near|me|nearby)\b/.test(s)) return 'local';
+  if (/\bwho\s+is\b/.test(s)) return 'people';
+  const words = s.split(/\s+/);
+  if (words.length <= 4 && /^[a-z .'-]+$/.test(s)) return 'people';
+  if (/\b(ltd|limited|inc|llc|plc|pvt|private|company|corp|co\.|enterprises)\b/.test(s)) return 'company';
+  return 'general';
+}

--- a/apps/web/lib/llm/provider.ts
+++ b/apps/web/lib/llm/provider.ts
@@ -1,0 +1,40 @@
+import OpenAI from "openai";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+function haveOpenAI() { return !!process.env.OPENAI_API_KEY; }
+function haveGemini() { return !!process.env.GEMINI_API_KEY; }
+
+async function tryOpenAI(prompt: string, system?: string, temperature=0.2) {
+  if (!haveOpenAI()) throw new Error("OPENAI_API_KEY missing");
+  const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+  const r = await client.chat.completions.create({
+    model, temperature,
+    messages: [{ role:"system", content: system || "" }, { role:"user", content: prompt }],
+  });
+  return (r.choices?.[0]?.message?.content || "").trim();
+}
+
+async function tryGemini(prompt: string, system?: string) {
+  if (!haveGemini()) throw new Error("GEMINI_API_KEY missing");
+  const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
+  const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-8b" });
+  const res = await model.generateContent({
+    contents: [{ role: "user", parts: [{ text: (system?system+"\n\n":"") + prompt }]}],
+  });
+  const text = res.response?.candidates?.[0]?.content?.parts?.map((p:any)=>p.text).join("") || "";
+  return text.trim();
+}
+
+export async function generateText({ prompt, system, temperature=0.2 }: { prompt: string; system?: string; temperature?: number; }): Promise<string> {
+  // Auto: prefer OpenAI, fallback Gemini, or vice versa based on availability
+  const prefs = haveOpenAI() ? ["openai","gemini"] : ["gemini","openai"];
+  for (const p of prefs) {
+    try {
+      return p === "openai" ? await tryOpenAI(prompt, system, temperature) : await tryGemini(prompt, system);
+    } catch (e) {
+      // try next
+    }
+  }
+  throw new Error("No LLM provider is available (OPENAI_API_KEY or GEMINI_API_KEY required).");
+}

--- a/apps/web/lib/llm/tasks.ts
+++ b/apps/web/lib/llm/tasks.ts
@@ -1,0 +1,45 @@
+import { generateText } from "./provider";
+
+export async function summarizeWithCitations(opts: {
+  subject: string;
+  sources: { title: string; url: string }[];
+  style?: "simple" | "expert";
+}): Promise<string> {
+  const system = `You are Wizkid. Write a concise answer in ≤200 words.
+- Use inline [n] citations that match the numbered list provided.
+- No speculation; only use the listed sources.
+- Tone: ${opts.style === "expert" ? "Expert" : "Simple"}.`;
+
+  const sourceList = opts.sources.map((s, i) => `[${i+1}] ${s.title} — ${s.url}`).join("\n");
+  const prompt = `${system}
+
+Subject/Query: ${opts.subject}
+
+Numbered sources:
+${sourceList}`;
+
+  return generateText({ prompt, system });
+}
+
+export async function expandQueries(query: string): Promise<string[]> {
+  const system = "You are a helpful search strategist.";
+  const prompt = `Rewrite and expand the user query for web search. 
+Return 4–6 short diverse queries, one per line, no numbering.
+User query: ${query}`;
+  const text = await generateText({ prompt, system });
+  return text.split("\n").map(s=>s.trim()).filter(Boolean).slice(0,6);
+}
+
+export async function relatedSuggestions(subject: string): Promise<{label:string; prompt:string}[]> {
+  const system = "You generate follow-up questions that are actionable for search.";
+  const prompt = `Generate 5 concise follow-up questions (≤8 words each) about: ${subject}.
+Return as lines: label | full prompt`;
+  const text = await generateText({ prompt, system });
+  const lines = text.split("\n").map(s=>s.trim()).filter(Boolean);
+  const items = lines.map(l=>{
+    const [label, rest] = l.split("|");
+    const clean = (s?:string)=> (s||"").trim();
+    return { label: clean(label), prompt: clean(rest||label) };
+  }).filter(x=>x.label);
+  return items.slice(0,5);
+}

--- a/apps/web/lib/local/geoapify.ts
+++ b/apps/web/lib/local/geoapify.ts
@@ -1,0 +1,51 @@
+import type { Place } from '../types';
+
+const KEY = process.env.GEOAPIFY_KEY || '';
+
+function hav(lat1:number, lon1:number, lat2:number, lon2:number){
+  const R=6371000, toRad=(d:number)=>d*Math.PI/180, dLat=toRad(lat2-lat1), dLon=toRad(lon2-lon1);
+  const A=Math.sin(dLat/2)**2 + Math.cos(toRad(lat1))*Math.cos(toRad(lat2))*Math.sin(dLon/2)**2;
+  return 2*R*Math.asin(Math.sqrt(A));
+}
+
+export async function geoapifyPlaces(q: string, lat:number, lon:number, radius=6000): Promise<Place[]> {
+  if (!KEY) return [];
+  let cats:string[]=[];
+  const s=q.toLowerCase();
+  if (s.includes('lawyer') || s.includes('attorney') || s.includes('advocate')) cats=['service.lawyer'];
+  if (s.includes('doctor') || s.includes('clinic') || s.includes('physician')) cats=['healthcare.doctor','healthcare.clinic'];
+  if (s.includes('hospital')) cats=['healthcare.hospital'];
+  if (s.includes('dentist')) cats=['healthcare.dentist'];
+  if (s.includes('pharmacy')) cats=['healthcare.pharmacy'];
+  if (s.includes('restaurant')) cats=['catering.restaurant','catering.fast_food','catering.cafe'];
+  if (s.includes('cafe')) cats=['catering.cafe'];
+  if (s.includes('bank')) cats=['financial.bank'];
+  if (s.includes('atm')) cats=['financial.atm'];
+
+  const u = new URL('https://api.geoapify.com/v2/places');
+  u.searchParams.set('apiKey', KEY);
+  u.searchParams.set('filter', `circle:${lon},${lat},${Math.max(800, Math.min(15000, radius))}`);
+  u.searchParams.set('bias', `proximity:${lon},${lat}`);
+  if (cats.length) u.searchParams.set('categories', cats.join(','));
+  else u.searchParams.set('text', q);
+  u.searchParams.set('limit', '20');
+
+  const r = await fetch(u, { cache:'no-store' });
+  if (!r.ok) return [];
+  const j:any = await r.json();
+
+  return (j.features||[]).map((f:any)=> {
+    const p=f.properties||{}, g=f.geometry?.coordinates||[lon,lat];
+    const d = hav(lat,lon,g[1],g[0]);
+    return {
+      id: String(f.id || `${g[1]},${g[0]}`),
+      name: p.name || p.address_line1 || 'Unknown',
+      address: p.formatted,
+      lat: g[1], lon: g[0], distance_m: Math.round(d),
+      phone: p.datasource?.raw?.phone || p.contact?.phone,
+      website: p.website || p.datasource?.raw?.website,
+      category: (p.categories||[])[0],
+      source: 'geoapify' as const
+    };
+  });
+}

--- a/apps/web/lib/local/overpass.ts
+++ b/apps/web/lib/local/overpass.ts
@@ -1,0 +1,65 @@
+import type { Place } from '../types';
+
+const CATS: Record<string, { key: string; values: string[] }> = {
+  lawyer: { key:'office', values:['lawyer'] },
+  doctor: { key:'amenity', values:['doctors','clinic'] },
+  hospital:{ key:'amenity', values:['hospital'] },
+  dentist:{ key:'amenity', values:['dentist'] },
+  pharmacy:{ key:'amenity', values:['pharmacy'] },
+  restaurant:{ key:'amenity', values:['restaurant','fast_food','cafe'] },
+  cafe:{ key:'amenity', values:['cafe'] },
+  bank:{ key:'amenity', values:['bank'] },
+  atm:{ key:'amenity', values:['atm'] },
+};
+
+function detect(q:string){
+  const s=q.toLowerCase();
+  if (/lawyer|attorney|advocate/.test(s)) return 'lawyer';
+  for (const k of Object.keys(CATS)) if (s.includes(k)) return k;
+  return null;
+}
+
+function hav(lat1:number, lon1:number, lat2:number, lon2:number){
+  const R=6371000, toRad=(d:number)=>d*Math.PI/180, dLat=toRad(lat2-lat1), dLon=toRad(lon2-lon1);
+  const A=Math.sin(dLat/2)**2 + Math.cos(toRad(lat1))*Math.cos(toRad(lat2))*Math.sin(dLon/2)**2;
+  return 2*R*Math.asin(Math.sqrt(A));
+}
+
+export async function overpassPlaces(q:string, lat:number, lon:number, radius=6000): Promise<Place[]> {
+  const cat = detect(q); if (!cat) return [];
+  const tag=CATS[cat]; const around=`around:${Math.max(800,Math.min(15000,radius))},${lat},${lon}`;
+  const clauses = tag.values.map(v=>`node[${tag.key}=${v}](${around});way[${tag.key}=${v}](${around});relation[${tag.key}=${v}](${around});`).join('\n');
+  const ql = `[out:json][timeout:25];(${clauses});out center tags 80;`;
+  const headers = { 'Content-Type':'text/plain','Accept':'application/json','User-Agent':'Wizkid/1.0 (+https://example.com/contact)' } as any;
+  const eps = [
+    'https://overpass-api.de/api/interpreter',
+    'https://overpass.kumi.systems/api/interpreter',
+    'https://overpass.openstreetmap.ru/api/interpreter'
+  ];
+  for (const ep of eps) {
+    try {
+      const r = await fetch(ep,{ method:'POST', body: ql, headers, cache:'no-store' });
+      if (r.ok) {
+        const j:any = await r.json();
+        const out:Place[]=[];
+        for (const el of j.elements||[]) {
+          const tags=el.tags||{}, c=el.center||{lat:el.lat,lon:el.lon}, name=tags.name||tags['name:en'];
+          if (!name || !c?.lat || !c?.lon) continue;
+          const addr=[tags['addr:housenumber'],tags['addr:street'],tags['addr:city']].filter(Boolean).join(' ');
+          const d = hav(lat,lon,c.lat,c.lon);
+          out.push({
+            id:String(el.id), name, address: addr || undefined, lat:c.lat, lon:c.lon,
+            distance_m: Math.round(d),
+            phone:tags.phone||tags['contact:phone'],
+            website:tags.website||tags['contact:website'],
+            category: tags.amenity || tags.office,
+            source:'osm', osmUrl:`https://www.openstreetmap.org/${el.type}/${el.id}`
+          });
+        }
+        out.sort((a,b)=> (a.distance_m||0)-(b.distance_m||0));
+        return out.slice(0,20);
+      }
+    } catch {}
+  }
+  return [];
+}

--- a/apps/web/lib/text/similarity.ts
+++ b/apps/web/lib/text/similarity.ts
@@ -1,0 +1,19 @@
+export function normalizeName(s: string) {
+  return s.toLowerCase().normalize('NFKD').replace(/[\u0300-\u036f]/g,'').replace(/[^a-z0-9\s]/g,' ').replace(/\s+/g,' ').trim();
+}
+export function tokenSet(s: string): Set<string> {
+  return new Set(normalizeName(s).split(' ').filter(Boolean));
+}
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (!a.size && !b.size) return 0;
+  let inter = 0; for (const t of a) if (b.has(t)) inter++;
+  return inter / (a.size + b.size - inter || 1);
+}
+export function nameScore(query: string, candidate: string): number {
+  const qn = normalizeName(query), cn = normalizeName(candidate);
+  if (!qn || !cn) return 0;
+  if (qn === cn) return 1;
+  const jq = jaccard(tokenSet(qn), tokenSet(cn));
+  const prefix = (cn.startsWith(qn) || qn.startsWith(cn)) ? 0.15 : 0;
+  return Math.min(1, jq + prefix);
+}

--- a/apps/web/lib/text/spell.ts
+++ b/apps/web/lib/text/spell.ts
@@ -1,0 +1,17 @@
+export async function wikiSuggest(q: string): Promise<string | null> {
+  try {
+    const u = new URL('https://en.wikipedia.org/w/api.php');
+    u.searchParams.set('action','opensearch');
+    u.searchParams.set('search', q);
+    u.searchParams.set('limit','1');
+    u.searchParams.set('namespace','0');
+    u.searchParams.set('format','json');
+    u.searchParams.set('origin','*');
+    const r = await fetch(u, { cache: 'no-store' });
+    if (!r.ok) return null;
+    const j: any = await r.json();
+    const best: string | undefined = j?.[1]?.[0];
+    if (best && best.toLowerCase() !== q.toLowerCase()) return best;
+    return null;
+  } catch { return null; }
+}

--- a/apps/web/lib/think/orchestrator.ts
+++ b/apps/web/lib/think/orchestrator.ts
@@ -1,0 +1,72 @@
+import { detectIntent } from "../intent";
+import { wikiDisambiguate } from "../wiki";
+import { getWikidataSocials } from "../tools/wikidata";
+import { findSocialLinks, searchCSEMany, toCites } from "../tools/googleCSE";
+import { geoapifyPlaces } from "../local/geoapify";
+import { overpassPlaces } from "../local/overpass";
+import { nameScore } from "../text/similarity";
+import { wikiSuggest } from "../text/spell";
+import type { Orchestrated, Cite } from "../types";
+
+const norm = (u:string)=>{ try{const x=new URL(u); x.hash=''; x.search=''; return x.toString();}catch{return u;} };
+
+export async function planAndFetch(query: string, coords?: {lat:number, lon:number}): Promise<Orchestrated> {
+  let q = query.trim();
+  const intent = detectIntent(q);
+  const out: Orchestrated = { plan: { intent }, cites: [] };
+
+  const suggestion = await wikiSuggest(q);
+  if (suggestion && nameScore(q, suggestion) < 0.7) q = suggestion;
+  out.plan.subject = q;
+
+  // PEOPLE
+  if (intent === 'people') {
+    const { primary, others } = await wikiDisambiguate(q);
+    if (others?.length) out.candidates = others;
+    if (!primary || nameScore(q, primary.title) < 0.85) return { ...out, status: 'ambiguous' };
+    out.profile = primary;
+
+    // socials
+    const wd = await getWikidataSocials(primary.title);
+    const s  = await findSocialLinks(primary.title);
+
+    const prelim: Cite[] = [];
+    const push = (u?:string,t?:string,sn?:string)=>u && prelim.push({ id:String(prelim.length+1), url:norm(u), title:t||u, snippet:sn });
+
+    if (primary.pageUrl) push(primary.pageUrl, 'Wikipedia');
+    if (wd.website)  push(wd.website, 'Official website');
+    if (wd.linkedin) push(wd.linkedin, 'LinkedIn');
+    if (wd.instagram)push(wd.instagram,'Instagram');
+    if (wd.facebook) push(wd.facebook, 'Facebook');
+    if (wd.x)        push(wd.x,        'X (Twitter)');
+
+    const pick = (h?:any)=> h && push(h.url, h.title, h.snippet);
+    pick(s.linkedin); pick(s.insta); pick(s.fb); pick(s.x);
+
+    const webHits = await searchCSEMany([
+      primary.title, `${primary.title} official`, `${primary.title} interview`, `${primary.title} achievements`
+    ], 3);
+
+    toCites(webHits).forEach(c=>push(c.url,c.title,c.snippet));
+
+    const seen = new Set<string>(); out.cites = [];
+    for (const c of prelim) { if (!seen.has(c.url)) { seen.add(c.url); out.cites.push({ ...c, id: String(out.cites.length+1) }); } if (out.cites.length>=10) break; }
+    return out;
+  }
+
+  // LOCAL
+  if (intent === 'local') {
+    if (!coords?.lat || !coords?.lon) return { ...out, plan:{...out.plan, needLocation:true}, status:'need_location' };
+    const g = await geoapifyPlaces(q, coords.lat, coords.lon, 6000);
+    const o = await overpassPlaces(q, coords.lat, coords.lon, 6000);
+    const merged = [...g, ...o];
+    return { ...out, places: merged, status: `local:${q} (${merged.length} found)` };
+  }
+
+  // COMPANY / GENERAL
+  {
+    const web = await searchCSEMany([ q, `${q} official site`, `${q} overview`, `${q} directors`, `${q} contact`, `${q} review` ], 4);
+    out.cites = toCites(web, 10);
+    return out;
+  }
+}

--- a/apps/web/lib/tools/googleCSE.ts
+++ b/apps/web/lib/tools/googleCSE.ts
@@ -1,0 +1,58 @@
+import type { Cite } from '../types';
+
+type Hit = { url: string; title: string; snippet?: string };
+
+const ID  = process.env.GOOGLE_CSE_ID || '';
+const KEY = process.env.GOOGLE_CSE_KEY || '';
+
+function ok() { return !!ID && !!KEY; }
+const norm = (u:string)=>{ try{const x=new URL(u); x.hash=''; x.search=''; return x.toString();}catch{return u;} };
+
+export async function searchCSE(query: string, num = 5): Promise<Hit[]> {
+  if (!ok()) return [];
+  const u = new URL('https://www.googleapis.com/customsearch/v1');
+  u.searchParams.set('q', query);
+  u.searchParams.set('cx', ID);
+  u.searchParams.set('key', KEY);
+  u.searchParams.set('num', String(Math.min(10, Math.max(1, num))));
+  const r = await fetch(u, { cache:'no-store' });
+  if (!r.ok) return [];
+  const j:any = await r.json();
+  return (j.items || []).map((it:any)=>({ url:norm(it.link), title:it.title, snippet:it.snippet }));
+}
+
+export async function searchCSEMany(queries: string[], perQuery = 3): Promise<Hit[]> {
+  if (!ok()) return [];
+  const out:Hit[]=[]; const seen = new Set<string>();
+  for (const q of queries) {
+    const part = await searchCSE(q, perQuery);
+    for (const h of part) {
+      if (!seen.has(h.url)) { seen.add(h.url); out.push(h); }
+      if (out.length>=12) break;
+    }
+    if (out.length>=12) break;
+  }
+  return out;
+}
+
+export function cseMissing(): boolean { return !ok(); }
+
+export async function findSocialLinks(name: string) {
+  const q = (site:string)=>searchCSE(`site:${site} ${name}`, 2);
+  const [wiki, linkedin, insta, fb, x] = await Promise.all([
+    q('wikipedia.org'), q('linkedin.com'), q('instagram.com'), q('facebook.com'),
+    Promise.race([q('x.com'), q('twitter.com')])
+  ]);
+  const pick = (arr:Hit[]) => arr?.[0];
+  return { wiki:pick(wiki), linkedin:pick(linkedin), insta:pick(insta), fb:pick(fb), x:pick(x) };
+}
+
+export function toCites(hits: Hit[], max = 10): Cite[] {
+  const seen = new Set<string>(); const cites: Cite[] = [];
+  for (const h of hits) {
+    const u = norm(h.url);
+    if (!seen.has(u)) { seen.add(u); cites.push({ id:String(cites.length+1), url:u, title:h.title, snippet:h.snippet }); }
+    if (cites.length >= max) break;
+  }
+  return cites;
+}

--- a/apps/web/lib/tools/wikidata.ts
+++ b/apps/web/lib/tools/wikidata.ts
@@ -1,0 +1,43 @@
+export async function getWikidataSocials(label: string) {
+  try {
+    const s = new URL('https://www.wikidata.org/w/api.php');
+    s.searchParams.set('action','wbsearchentities');
+    s.searchParams.set('search', label);
+    s.searchParams.set('language','en');
+    s.searchParams.set('format','json');
+    s.searchParams.set('limit','1');
+    s.searchParams.set('origin','*');
+    const sr = await fetch(s, { cache:'no-store' });
+    const sj:any = await sr.json();
+    const id:string|undefined = sj?.search?.[0]?.id;
+    if (!id) return {};
+
+    const d = new URL('https://www.wikidata.org/w/api.php');
+    d.searchParams.set('action','wbgetentities');
+    d.searchParams.set('ids', id);
+    d.searchParams.set('props','claims');
+    d.searchParams.set('format','json');
+    d.searchParams.set('origin','*');
+    const dr = await fetch(d, { cache:'no-store' });
+    const dj:any = await dr.json();
+
+    const cl = dj?.entities?.[id]?.claims || {};
+    const getStr = (pid:string) => {
+      const v = cl[pid]?.[0]?.mainsnak?.datavalue?.value;
+      return typeof v === 'string' ? v : (v?.text || v?.id || '');
+    };
+    const website = getStr('P856'),
+          twitter = getStr('P2002'),
+          instagram = getStr('P2003'),
+          facebook = getStr('P2013'),
+          linkedinId = getStr('P6634');
+
+    const out:any = {};
+    if (website)  out.website  = website;
+    if (linkedinId) out.linkedin = `https://www.linkedin.com/in/${linkedinId}`;
+    if (instagram) out.instagram = `https://www.instagram.com/${instagram}`;
+    if (facebook)  out.facebook  = `https://www.facebook.com/${facebook}`;
+    if (twitter)   out.x        = `https://x.com/${twitter}`;
+    return out;
+  } catch { return {}; }
+}

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -1,0 +1,18 @@
+export type Cite = { id: string; url: string; title: string; snippet?: string };
+export type Profile = { title: string; description?: string; extract?: string; pageUrl?: string; image?: string };
+export type Candidate = { title: string; description?: string; pageUrl: string; image?: string };
+export type Place = { id: string; name: string; address?: string; lat: number; lon: number; distance_m?: number; phone?: string; website?: string; category?: string; source: 'geoapify'|'osm'; osmUrl?: string };
+
+export type Plan = {
+  intent: 'people'|'company'|'local'|'general';
+  subject?: string;
+  needLocation?: boolean;
+};
+export type Orchestrated = {
+  plan: Plan;
+  profile?: Profile | null;
+  candidates?: Candidate[];
+  cites: Cite[];
+  places?: Place[];
+  status?: string;
+};

--- a/apps/web/lib/wiki.ts
+++ b/apps/web/lib/wiki.ts
@@ -1,0 +1,43 @@
+import type { Profile, Candidate } from './types';
+
+function wikiPageUrl(title: string) {
+  const t = encodeURIComponent(title.replace(/\s/g, '_'));
+  return `https://en.wikipedia.org/wiki/${t}`;
+}
+
+async function fetchSummaryByTitle(title: string): Promise<Profile | null> {
+  const r = await fetch(
+    `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}?redirect=true`,
+    { next:{ revalidate:3600 } }
+  );
+  if (!r.ok) return null;
+  const j:any = await r.json();
+  return {
+    title: j.title,
+    description: j.description,
+    extract: j.extract,
+    pageUrl: j.content_urls?.desktop?.page || wikiPageUrl(j.title),
+    image: j.originalimage?.source || j.thumbnail?.source
+  };
+}
+
+export async function searchWikiCandidates(q: string, n = 6): Promise<Candidate[]> {
+  const r = await fetch(
+    `https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=${encodeURIComponent(q)}&format=json&srlimit=${n}&utf8=1&origin=*`,
+    { cache:'no-store' }
+  );
+  if (!r.ok) return [];
+  const j:any = await r.json();
+  const titles: string[] = (j?.query?.search || []).map((s:any)=>s.title);
+  return (await Promise.all(titles.map(async t => {
+    const s = await fetchSummaryByTitle(t);
+    return { title:t, description:s?.description, pageUrl:s?.pageUrl || wikiPageUrl(t), image:s?.image } as Candidate;
+  })));
+}
+
+export async function wikiDisambiguate(q: string): Promise<{ primary: Profile | null; others: Candidate[] }> {
+  const cands = await searchWikiCandidates(q, 6);
+  const primaryTitle = cands[0]?.title;
+  const primary = primaryTitle ? await fetchSummaryByTitle(primaryTitle) : null;
+  return { primary, others: cands.slice(1) };
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: { serverActions: false }
+};
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@wizkid/web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@google/generative-ai": "^0.21.0",
+    "next": "14.2.5",
+    "openai": "^4.56.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.7",
+    "typescript": "^5.4.5"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = { plugins: { tailwindcss: {}, autoprefixer: {} } };

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./app/**/*.{ts,tsx}"],
+  theme: { extend: {} },
+  plugins: [require("@tailwindcss/typography")]
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@lib/*": ["lib/*"]
+    }
+  },
+  "include": ["app", "lib", "next-env.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@google/generative-ai": "^0.21.0",
         "@upstash/redis": "^1.31.6",
         "next": "14.2.5",
+        "openai": "^4.56.0",
         "react": "18.3.1",
         "react-dom": "18.3.1"
       },
@@ -688,10 +689,19 @@
       "version": "20.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
       "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/prop-types": {
@@ -1158,6 +1168,18 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1179,6 +1201,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1456,6 +1490,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1640,7 +1680,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1803,6 +1842,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -1978,6 +2029,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2022,7 +2082,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2127,7 +2186,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2137,7 +2195,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2175,7 +2232,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2188,7 +2244,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2820,6 +2875,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2979,6 +3043,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -3019,7 +3118,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3060,7 +3158,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3085,7 +3182,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3218,7 +3314,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3296,7 +3391,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3309,7 +3403,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3325,13 +3418,21 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/ignore": {
@@ -4076,7 +4177,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4104,6 +4204,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -4146,7 +4267,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4278,6 +4398,46 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -4449,6 +4609,47 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.56.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.56.0.tgz",
+      "integrity": "sha512-zcag97+3bG890MNNa0DQD9dGmmTWL8unJdNkulZzWRXrl+QeD+YkBI4H58rJcwErxqGK6a0jVPZ4ReJjhDGcmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -5819,6 +6020,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -6005,7 +6212,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6090,6 +6296,31 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,23 +9,26 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "14.2.5",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
     "@google/generative-ai": "^0.21.0",
-    "@upstash/redis": "^1.31.6"
+    "@upstash/redis": "^1.31.6",
+    "next": "14.2.5",
+    "openai": "^4.56.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
-    "@types/node": "^20.11.0",
-    "@types/express": "^4.17.21",
     "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.0",
     "@types/react": "^18.3.3",
-    "tailwindcss": "^3.4.10",
-    "postcss": "^8.4.41",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
-    "eslint-config-next": "14.2.5"
+    "eslint-config-next": "14.2.5",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.4.0"
   },
-  "engines": { "node": ">=20 <21" }
+  "engines": {
+    "node": ">=20 <21"
+  }
 }


### PR DESCRIPTION
## Summary
- add Next.js web app with unified LLM provider that prefers OpenAI and falls back to Gemini
- implement orchestrator for intent detection, wiki and web search, and local place lookup
- expose streaming `/api/ask` endpoint and basic UI with sources, suggestions, and feedback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b06edcc74c832f8742429008892b1c