### PR TITLE
feat: auto-select LLM provider and add IP fallback

### DIFF
--- a/apps/web/lib/geo/ip.ts
+++ b/apps/web/lib/geo/ip.ts
@@ -1,0 +1,21 @@
+export type Coords = { lat: number; lon: number };
+
+export async function ipLocate(): Promise<Coords | null> {
+  try {
+    const r = await fetch('https://ipapi.co/json/', { cache: 'no-store' });
+    if (r.ok) {
+      const j: any = await r.json();
+      const lat = Number(j.latitude), lon = Number(j.longitude);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) return { lat, lon };
+    }
+  } catch {}
+  try {
+    const r = await fetch('https://ipwho.is/', { cache: 'no-store' });
+    if (r.ok) {
+      const j: any = await r.json();
+      const lat = Number(j.latitude), lon = Number(j.longitude);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) return { lat, lon };
+    }
+  } catch {}
+  return null;
+}

--- a/apps/web/lib/intent.ts
+++ b/apps/web/lib/intent.ts
@@ -2,11 +2,22 @@ export type Intent = 'people' | 'company' | 'local' | 'general';
 
 export function detectIntent(q: string): Intent {
   const s = q.trim().toLowerCase();
+
+  // must-catch local phrases
   if (/\bnear\s*me\b|\bnearby\b/.test(s)) return 'local';
-  if (/\b(doctor|clinic|hospital|dentist|pharmacy|restaurant|cafe|bank|atm|lawyer|attorney|advocate|property)\b/.test(s) && /\b(near|me|nearby)\b/.test(s)) return 'local';
+
+  // "doc", "dr", "gp" synonyms → doctor/clinic intent
+  if ((/\b(doc|dr|gp|doctor|clinic|hospital|dentist|pharmacy|restaurant|cafe|bank|atm|lawyer|attorney|advocate)\b/.test(s))
+      && (/\b(near|me|nearby)\b/.test(s))) return 'local';
+
   if (/\bwho\s+is\b/.test(s)) return 'people';
+
+  // short, name-like queries → people
   const words = s.split(/\s+/);
   if (words.length <= 4 && /^[a-z .'-]+$/.test(s)) return 'people';
-  if (/\b(ltd|limited|inc|llc|plc|pvt|private|company|corp|co\.|enterprises)\b/.test(s)) return 'company';
+
+  // org/company hints
+  if (/\b(ltd|limited|inc|llc|plc|pvt|private|company|corp|corporation|co\.|enterprises|labs)\b/.test(s)) return 'company';
+
   return 'general';
 }

--- a/apps/web/lib/llm/openai.ts
+++ b/apps/web/lib/llm/openai.ts
@@ -1,0 +1,17 @@
+import OpenAI from "openai";
+
+export async function openaiGenerate(prompt: string, system?: string, model?: string): Promise<string> {
+  const key = process.env.OPENAI_API_KEY; 
+  if (!key) throw new Error("OPENAI_API_KEY missing");
+  const client = new OpenAI({ apiKey: key });
+  const usedModel = model || process.env.OPENAI_MODEL || "gpt-4o-mini";
+  const r = await client.chat.completions.create({
+    model: usedModel,
+    temperature: 0.2,
+    messages: [
+      { role:"system", content: system || "You are Wizkid, a concise, citation-first assistant." },
+      { role:"user", content: prompt }
+    ]
+  });
+  return (r.choices?.[0]?.message?.content || "").trim();
+}


### PR DESCRIPTION
## Summary
- add LLM tasks helper that chooses OpenAI or Gemini and streams citation-first summaries
- introduce reusable OpenAI chat helper
- improve intent detection and API route with provider reporting and IP-based location fallback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1475de7ac832fb7d4c1d8b7427b95